### PR TITLE
Declare compatibility with Drupal 10.

### DIFF
--- a/islandora_workbench_integration.info.yml
+++ b/islandora_workbench_integration.info.yml
@@ -2,8 +2,7 @@ name: 'Islandora Workbench Integration'
 description: "Utilities for use with Islandora Workbench."
 type: module
 package: Islandora
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^9 || ^10
 dependencies:
   - islandora
 version: '1.0.0'


### PR DESCRIPTION
From the looks of the deprecation scans I've done (Drupal Rector and Upgrade Status), the only thing to make this module work with the latest releases of Drupal is to change the core version requirement. 

This does that.