### PR TITLE
Version endpoint: now needs to allow JWT_AUTH and COOKIE auth explicitly

### DIFF
--- a/islandora_workbench_integration.routing.yml
+++ b/islandora_workbench_integration.routing.yml
@@ -5,7 +5,7 @@ islandora_workbench_integration.core_version:
   requirements:
     _permission: 'administer site configuration'
   options:
-    _auth: ['basic_auth']
+    _auth: ['basic_auth','jwt_auth','cookie']
 
 islandora_workbench_integration.version:
   path: '/islandora_workbench_integration/version'
@@ -14,7 +14,7 @@ islandora_workbench_integration.version:
   requirements:
     _permission: 'administer site configuration'
   options:
-    _auth: ['basic_auth']
+    _auth: ['basic_auth','jwt_auth','cookie']
 
 islandora_workbench_integration.file_hash:
   path: '/islandora_workbench_integration/file_hash'
@@ -23,4 +23,4 @@ islandora_workbench_integration.file_hash:
   requirements:
     _permission: 'administer site configuration'
   options:
-    _auth: ['basic_auth']
+    _auth: ['basic_auth','jwt_auth','cookie']


### PR DESCRIPTION
Up until relatively recently, we could log in as a Drupal admin and then view the 

/islandora_workbench_integration/version

Endpoint and it would resolve. We have some tests that require that this is true. When we updated some modules including Drupal 10.3.2, we're now getting 

`Path: /islandora_workbench_integration/version. Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException: The used authentication method is not allowed on this route. in Drupal\Core\EventSubscriber\AuthenticationSubscriber->onExceptionAccessDenied() (line 135 of /var/www/drupal/web/core/lib/Drupal/Core/EventSubscriber/AuthenticationSubscriber.php).`

Unless you're explicitly using basic auth. This PR allows `jwt_auth` and `cookie` auth methods to continue to work. 