### PR TITLE
Add Drupal 11 support and CI tests

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,41 @@
+name: lint-test
+
+on:
+  push:
+    branches:
+      - "**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-test:
+    name: lint+test
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        php-version: ["8.1", "8.2", "8.3"]
+        drupal-version: ["10.3", "10.4", "11.0", "11.1"]
+        exclude:
+          - drupal-version: "11.0"
+            php-version: "8.1"
+          - drupal-version: "11.0"
+            php-version: "8.2"
+          - drupal-version: "11.1"
+            php-version: "8.1"
+          - drupal-version: "11.1"
+            php-version: "8.2"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: lint+test
+        working-directory: tests
+        run: |
+          export MODULE_DIRECTORY=$(pwd | xargs dirname)
+          docker compose up --quiet-pull --abort-on-container-exit
+        env:
+          DRUPAL_VERSION: ${{ matrix.drupal-version }}
+          PHP_VERSION: ${{ matrix.php-version }}
+          ENABLE_MODULES: islandora_workbench_integration

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Drupal 9/10 Module required by [Islandora Workbench](https://github.com/mjordan/islandora_workbench). Enables the following Views:
+Drupal 10/11 Module required by [Islandora Workbench](https://github.com/mjordan/islandora_workbench). Enables the following Views:
 
 * Term from URI
 * Term from term name
@@ -61,11 +61,24 @@ Or, if you are using ISLE:
 1. `docker-compose exec -T drupal with-contenv bash -lc "drush cim -y --partial --source=modules/contrib/islandora_workbench_integration/config/optional"`
 1. `docker-compose exec -T drupal with-contenv bash -lc "drush cr"`
 
-Note that as of the 1.0.0 release, the "Terms in vocabulary" View is no longer used by Workbench. Unless you are using this View for some other purpose, as of version 1.0.0 you can disable/delete it from your Drupal. 
+Note that as of the 1.0.0 release, the "Terms in vocabulary" View is no longer used by Workbench. Unless you are using this View for some other purpose, as of version 1.0.0 you can disable/delete it from your Drupal.
 
 ## Permissions
 
 All REST endpoints added or endabled by this module require the use of Basic Authentication. The username/password combination used in your Islandora Workbench configuration files should be a member of the "Administrator" role.
+
+## Running tests locally
+
+A docker-compose.yml file is defined in [./tests](./tests) that can automatically lint and run phpunit tests for this module. These are how tests are ran [in GitHub Actions](./.github/workflows/lint-test.yml).
+
+```bash
+cd tests
+export MODULE_DIRECTORY=$(pwd | xargs dirname)
+export ENABLE_MODULES=islandora_workbench_integration
+export DRUPAL_VERSION=10.4
+export PHP_VERSION=8.3
+docker compose up --quiet-pull --abort-on-container-exit
+```
 
 ## Current maintainer
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
   "support": {
     "issues": "https://github.com/mjordan/islandora_workbench_integration/issues"
   },
+  "require": {
+    "drupal/islandora": "^2"
+  },
   "authors": [
     {
       "name": "Mark Jordan",

--- a/config/optional/views.view.term_from_term_name.yml
+++ b/config/optional/views.view.term_from_term_name.yml
@@ -163,7 +163,6 @@ display:
             query_param: uri
             fallback: ''
             multiple: and
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -239,7 +238,6 @@ display:
             query_param: name
             fallback: ''
             multiple: and
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -284,7 +282,6 @@ display:
             query_param: vocab
             fallback: ''
             multiple: and
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/config/optional/views.view.term_from_uri.yml
+++ b/config/optional/views.view.term_from_uri.yml
@@ -162,7 +162,6 @@ display:
             query_param: uri
             fallback: ''
             multiple: and
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -238,7 +237,6 @@ display:
             query_param: uri
             fallback: ''
             multiple: and
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true
@@ -315,7 +313,6 @@ display:
             query_param: authority_link
             fallback: ''
             multiple: and
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/islandora_workbench_integration.info.yml
+++ b/islandora_workbench_integration.info.yml
@@ -1,8 +1,8 @@
-name: 'Islandora Workbench Integration'
+name: "Islandora Workbench Integration"
 description: "Utilities for use with Islandora Workbench."
 type: module
 package: Islandora
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
-  - islandora
-version: '1.0.0'
+  - islandora:islandora
+version: "1.1.0"

--- a/src/Controller/IslandoraWorkbenchIntegrationCoreVersionController.php
+++ b/src/Controller/IslandoraWorkbenchIntegrationCoreVersionController.php
@@ -6,15 +6,18 @@ use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
-* Controller.
-*/
+ * Controller.
+ */
 class IslandoraWorkbenchIntegrationCoreVersionController extends ControllerBase {
+
   /**
-   * @return JsonResponse object
+   * Return a JSON object specifying this site's Drupal version.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   object
    */
-   public function main() {
-     return new JsonResponse(['core_version' => \Drupal::VERSION]);
-   }
+  public function main() {
+    return new JsonResponse(['core_version' => \Drupal::VERSION]);
+  }
 
 }
-

--- a/src/Controller/IslandoraWorkbenchIntegrationGetHashController.php
+++ b/src/Controller/IslandoraWorkbenchIntegrationGetHashController.php
@@ -17,8 +17,8 @@ class IslandoraWorkbenchIntegrationGetHashController extends ControllerBase {
    * 'algorithm', to get a file entity's checksum. 'algorithm'
    * is one of 'md5', 'sha1', or 'sha256'.
    *
-   * @return JsonResponse
-   *   A JSON response with the keys below. 
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   A JSON response with the keys below.
    */
   public function main() {
     $file_uuid = \Drupal::request()->query->get('file_uuid');

--- a/src/Controller/IslandoraWorkbenchIntegrationGetHashController.php
+++ b/src/Controller/IslandoraWorkbenchIntegrationGetHashController.php
@@ -3,12 +3,52 @@
 namespace Drupal\islandora_workbench_integration\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Controller.
  */
 class IslandoraWorkbenchIntegrationGetHashController extends ControllerBase {
+
+  /**
+   * The current request.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a GetHash controller.
+   *
+   * @param \Symfony\Component\HttpFoundation\RequestStack $request_stack
+   *   The request stack.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(RequestStack $request_stack, EntityTypeManagerInterface $entity_type_manager) {
+    $this->request = $request_stack->getCurrentRequest();
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new static(
+      $container->get('request_stack'),
+      $container->get('entity_type.manager')
+    );
+  }
 
   /**
    * Gets the checksum of the file identified by the UUID.
@@ -20,24 +60,40 @@ class IslandoraWorkbenchIntegrationGetHashController extends ControllerBase {
    * @return \Symfony\Component\HttpFoundation\JsonResponse
    *   A JSON response with the keys below.
    */
-  public function main() {
-    $file_uuid = \Drupal::request()->query->get('file_uuid');
-    $algorithm = \Drupal::request()->query->get('algorithm');
+  public function main(): JsonResponse {
+    $file_uuid = $this->request->query->get('file_uuid');
+    $algorithm = $this->request->query->get('algorithm');
 
-    if (is_null($file_uuid) || is_null($algorithm)) {
-      return new JsonResponse(['error' => 'Request is missing either the "file_uuid" or "algorithm" parameter.']);
-    }
-    if (!in_array($algorithm, ['md5', 'sha1', 'sha256'])) {
-      return new JsonResponse(['error' => '"algorithm" parameter must be one of "md5", "sha1", or "sha256".']);
+    if ($file_uuid === NULL || $algorithm === NULL) {
+      return new JsonResponse([
+        'error' => 'Request is missing either the "file_uuid" or "algorithm" parameter.',
+      ]);
     }
 
-    $file = \Drupal::entityTypeManager()->getStorage('file')->loadByProperties(['uuid' => $file_uuid]);
-    $file = reset($file);
+    if (!in_array($algorithm, ['md5', 'sha1', 'sha256'], TRUE)) {
+      return new JsonResponse([
+        'error' => '"algorithm" parameter must be one of "md5", "sha1", or "sha256".',
+      ]);
+    }
+
+    $files = $this->entityTypeManager
+      ->getStorage('file')
+      ->loadByProperties(['uuid' => $file_uuid]);
+
+    $file = reset($files);
+    if (!$file) {
+      return new JsonResponse([
+        'error' => sprintf('No file found with UUID %s.', $file_uuid),
+      ]);
+    }
+
     $checksum = hash_file($algorithm, $file->getFileUri());
-    $response[] = [
-      'checksum' => $checksum,
-      'file_uuid' => $file->uuid(),
-      'algorithm' => $algorithm,
+    $response = [
+      [
+        'checksum' => $checksum,
+        'file_uuid' => $file->uuid(),
+        'algorithm' => $algorithm,
+      ],
     ];
 
     return new JsonResponse($response);

--- a/src/Controller/IslandoraWorkbenchIntegrationVersionController.php
+++ b/src/Controller/IslandoraWorkbenchIntegrationVersionController.php
@@ -6,15 +6,18 @@ use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**
-* Controller.
-*/
+ * Controller.
+ */
 class IslandoraWorkbenchIntegrationVersionController extends ControllerBase {
+
   /**
-   * @return JsonResponse object
+   * Return a JSON object specifying this module's version.
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   *   object
    */
-   public function main() {
-     return new JsonResponse(['integration_module_version' => '1.0.0']);
-   }
+  public function main() {
+    return new JsonResponse(['integration_module_version' => '1.0.0']);
+  }
 
 }
-

--- a/src/Controller/IslandoraWorkbenchIntegrationVersionController.php
+++ b/src/Controller/IslandoraWorkbenchIntegrationVersionController.php
@@ -3,12 +3,37 @@
 namespace Drupal\islandora_workbench_integration\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Extension\ModuleExtensionList;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Controller.
  */
 class IslandoraWorkbenchIntegrationVersionController extends ControllerBase {
+
+  /**
+   * The entity type manager service.
+   *
+   * @var \Drupal\Core\Extension\ModuleExtensionList
+   */
+  protected $moduleExtensionList;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(ModuleExtensionList $module_extention_list) {
+    $this->moduleExtensionList = $module_extention_list;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new static(
+      $container->get('extension.list.module')
+    );
+  }
 
   /**
    * Return a JSON object specifying this module's version.
@@ -17,7 +42,9 @@ class IslandoraWorkbenchIntegrationVersionController extends ControllerBase {
    *   object
    */
   public function main() {
-    return new JsonResponse(['integration_module_version' => '1.0.0']);
+    $version = $this->moduleExtensionList->getExtensionInfo('islandora_workbench_integration')['version'] ?? 0;
+
+    return new JsonResponse(['integration_module_version' => $version]);
   }
 
 }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,22 @@
+networks:
+  default:
+services:
+  chromedriver:
+    image: drupalci/webdriver-chromedriver:production
+    entrypoint:
+      - chromedriver
+      - "--log-path=/dev/null"
+      - "--verbose"
+      - "--allowed-ips="
+      - "--allowed-origins=*"
+  drupal:
+    image: lehighlts/drupal-ci:${DRUPAL_VERSION}-php${PHP_VERSION}
+    volumes:
+      - ${MODULE_DIRECTORY}:/var/www/drupal/web/modules/contrib/${ENABLE_MODULES}
+    environment:
+      SIMPLETEST_BASE_URL: http://drupal:8282
+      ENABLE_MODULES: ${ENABLE_MODULES}
+      MINK_DRIVER_ARGS_WEBDRIVER: '["chrome", {"browserName":"chrome","goog:chromeOptions":{"args":["--disable-gpu","--headless", "--no-sandbox", "--disable-dev-shm-usage"]}}, "http://chromedriver:9515"]'
+      SYMFONY_DEPRECATIONS_HELPER: weak
+    links: 
+        - chromedriver

--- a/tests/src/Functional/IslandoraWorkbenchIntegrationCoreVersionControllerTest.php
+++ b/tests/src/Functional/IslandoraWorkbenchIntegrationCoreVersionControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Drupal\Tests\islandora_workbench_integration\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the core-version controller.
+ *
+ * @group islandora_workbench_integration
+ */
+class IslandoraWorkbenchIntegrationCoreVersionControllerTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['islandora_workbench_integration'];
+
+  /**
+   * Tests that the core-version endpoint returns the Drupal version.
+   */
+  public function testCoreVersionJson() {
+    $this->drupalLogin($this->rootUser);
+
+    $this->drupalGet('/islandora_workbench_integration/core_version');
+    $this->assertSession()->statusCodeEquals(200);
+    $data = json_decode($this->getSession()->getPage()->getContent(), TRUE);
+    $this->assertArrayHasKey('core_version', $data);
+    $this->assertEquals(\Drupal::VERSION, $data['core_version']);
+  }
+
+}

--- a/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
+++ b/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\Tests\islandora_workbench_integration\Functional;
+
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\file\Entity\File;
+
+/**
+ * Tests the GetHash controller.
+ *
+ * @group islandora_workbench_integration
+ */
+class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['islandora_workbench_integration', 'file'];
+
+  /**
+   * A file entity for testing.
+   *
+   * @var \Drupal\file\FileInterface
+   */
+  protected $testFile;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->drupalLogin($this->rootUser);
+
+    // Create a small temporary file on disk.
+    $file_system = \Drupal::service('file_system');
+    $path = $this->root . '/sites/simpletest/files/test.txt';
+    $file_system->prepareDirectory($dir, FileSystemInterface::CREATE_DIRECTORY);
+    $file_system->saveData('hello world', $path, FileSystemInterface::EXISTS_REPLACE);
+
+    // Create a Drupal file entity pointing to it.
+    $this->testFile = File::create([
+      'uri' => 'public://test.txt',
+      // Copy into public://.
+      'status' => 0,
+    ]);
+    // Physically copy.
+    $file_system->copy($path, 'public://test.txt', FileSystemInterface::EXISTS_REPLACE);
+    $this->testFile->save();
+  }
+
+  /**
+   * Tests missing parameters.
+   */
+  public function testMissingParameters() {
+    // No query parameters at all.
+    $this->drupalGet('/islandora_workbench_integration/file_hash');
+    $this->assertSession()->statusCodeEquals(200);
+    $data = json_decode($this->getSession()->getPage()->getContent(), TRUE);
+    $this->assertEquals(
+      'Request is missing either the "file_uuid" or "algorithm" parameter.',
+      $data['error']
+    );
+  }
+
+  /**
+   * Tests invalid algorithm parameter.
+   */
+  public function testInvalidAlgorithm() {
+    $uuid = $this->testFile->uuid();
+    $this->drupalGet("/islandora_workbench_integration/file_hash?file_uuid={$uuid}&algorithm=foo");
+    $this->assertSession()->statusCodeEquals(200);
+    $data = json_decode($this->getSession()->getPage()->getContent(), TRUE);
+    $this->assertEquals(
+      '"algorithm" parameter must be one of "md5", "sha1", or "sha256".',
+      $data['error']
+    );
+  }
+
+  /**
+   * Tests valid request returns correct checksum.
+   */
+  public function testValidChecksumResponse() {
+    $uuid = $this->testFile->uuid();
+
+    // Compute expected checksum for our test.txt with "hello world\n"
+    // or no newline
+    // We saved exactly "hello world" (no newline).
+    $public_path = \Drupal::service('file_system')->realpath($this->testFile->getFileUri());
+    $expected = hash_file('md5', $public_path);
+
+    $this->drupalGet("/islandora_workbench_integration/file_hash?file_uuid={$uuid}&algorithm=md5");
+    $this->assertSession()->statusCodeEquals(200);
+
+    $data = json_decode($this->getSession()->getPage()->getContent(), TRUE);
+    // The controller wraps result in a numeric array.
+    $this->assertCount(1, $data);
+    $item = reset($data);
+    $this->assertEquals($expected, $item['checksum']);
+    $this->assertEquals($uuid, $item['file_uuid']);
+    $this->assertEquals('md5', $item['algorithm']);
+  }
+
+}

--- a/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
+++ b/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
@@ -36,8 +36,6 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
   protected function setUp(): void {
     parent::setUp();
 
-    $this->drupalLogin($this->rootUser);
-
     // Create a small temporary file on disk.
     $file_system = \Drupal::service('file_system');
     $path = '/tmp/test.txt';
@@ -60,6 +58,8 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
    * Tests missing parameters.
    */
   public function testMissingParameters() {
+    $this->drupalLogin($this->rootUser);
+
     // No query parameters at all.
     $this->drupalGet('/islandora_workbench_integration/file_hash');
     $this->assertSession()->statusCodeEquals(200);
@@ -74,6 +74,8 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
    * Tests invalid algorithm parameter.
    */
   public function testInvalidAlgorithm() {
+    $this->drupalLogin($this->rootUser);
+
     $uuid = $this->testFile->uuid();
     $this->drupalGet("/islandora_workbench_integration/file_hash?file_uuid={$uuid}&algorithm=foo");
     $this->assertSession()->statusCodeEquals(200);
@@ -88,6 +90,8 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
    * Tests valid request returns correct checksum.
    */
   public function testValidChecksumResponse() {
+    $this->drupalLogin($this->rootUser);
+
     $uuid = $this->testFile->uuid();
 
     // Compute expected checksum for our test.txt with "hello world\n"

--- a/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
+++ b/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
@@ -35,6 +35,7 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
    */
   protected function setUp(): void {
     parent::setUp();
+    $this->drupalLogin($this->rootUser);
 
     // Create a small temporary file on disk.
     $file_system = \Drupal::service('file_system');
@@ -58,8 +59,6 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
    * Tests missing parameters.
    */
   public function testMissingParameters() {
-    $this->drupalLogin($this->rootUser);
-
     // No query parameters at all.
     $this->drupalGet('/islandora_workbench_integration/file_hash');
     $this->assertSession()->statusCodeEquals(200);
@@ -74,10 +73,13 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
    * Tests invalid algorithm parameter.
    */
   public function testInvalidAlgorithm() {
-    $this->drupalLogin($this->rootUser);
-
     $uuid = $this->testFile->uuid();
-    $this->drupalGet("/islandora_workbench_integration/file_hash?file_uuid={$uuid}&algorithm=foo");
+    $this->drupalGet('/islandora_workbench_integration/file_hash', [
+      'query' => [
+        'file_uuid' => $uuid,
+        'algorithm' => 'foo',
+      ],
+    ]);
     $this->assertSession()->statusCodeEquals(200);
     $data = json_decode($this->getSession()->getPage()->getContent(), TRUE);
     $this->assertEquals(
@@ -90,8 +92,6 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
    * Tests valid request returns correct checksum.
    */
   public function testValidChecksumResponse() {
-    $this->drupalLogin($this->rootUser);
-
     $uuid = $this->testFile->uuid();
 
     // Compute expected checksum for our test.txt with "hello world\n"
@@ -100,7 +100,12 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
     $public_path = \Drupal::service('file_system')->realpath($this->testFile->getFileUri());
     $expected = hash_file('md5', $public_path);
 
-    $this->drupalGet("/islandora_workbench_integration/file_hash?file_uuid={$uuid}&algorithm=md5");
+    $this->drupalGet('/islandora_workbench_integration/file_hash', [
+      'query' => [
+        'file_uuid' => $uuid,
+        'algorithm' => 'md5',
+      ],
+    ]);
     $this->assertSession()->statusCodeEquals(200);
 
     $data = json_decode($this->getSession()->getPage()->getContent(), TRUE);

--- a/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
+++ b/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
@@ -40,7 +40,8 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
 
     // Create a small temporary file on disk.
     $file_system = \Drupal::service('file_system');
-    $path = $this->root . '/sites/simpletest/files/test.txt';
+    $path = '/tmp/test.txt';
+    $dir = dirname($path);
     $file_system->prepareDirectory($dir, FileSystemInterface::CREATE_DIRECTORY);
     $file_system->saveData('hello world', $path, FileSystemInterface::EXISTS_REPLACE);
 

--- a/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
+++ b/tests/src/Functional/IslandoraWorkbenchIntegrationGetHashControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\Tests\islandora_workbench_integration\Functional;
 
+use Drupal\Core\File\FileExists;
 use Drupal\Core\File\FileSystemInterface;
 use Drupal\Tests\BrowserTestBase;
 use Drupal\file\Entity\File;
@@ -42,7 +43,7 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
     $path = '/tmp/test.txt';
     $dir = dirname($path);
     $file_system->prepareDirectory($dir, FileSystemInterface::CREATE_DIRECTORY);
-    $file_system->saveData('hello world', $path, FileSystemInterface::EXISTS_REPLACE);
+    $file_system->saveData('hello world', $path, FileExists::Replace);
 
     // Create a Drupal file entity pointing to it.
     $this->testFile = File::create([
@@ -51,7 +52,7 @@ class IslandoraWorkbenchIntegrationGetHashControllerTest extends BrowserTestBase
       'status' => 0,
     ]);
     // Physically copy.
-    $file_system->copy($path, 'public://test.txt', FileSystemInterface::EXISTS_REPLACE);
+    $file_system->copy($path, 'public://test.txt', FileExists::Replace);
     $this->testFile->save();
   }
 

--- a/tests/src/Functional/IslandoraWorkbenchIntegrationVersionControllerTest.php
+++ b/tests/src/Functional/IslandoraWorkbenchIntegrationVersionControllerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\Tests\islandora_workbench_integration\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests the version controller.
+ *
+ * @group islandora_workbench_integration
+ */
+class IslandoraWorkbenchIntegrationVersionControllerTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['islandora_workbench_integration'];
+
+  /**
+   * Test the version controller.
+   */
+  public function testModuleVersionJson() {
+    $this->drupalLogin($this->rootUser);
+
+    $this->drupalGet('/islandora_workbench_integration/version');
+    $this->assertSession()->statusCodeEquals(200);
+    $data = json_decode($this->getSession()->getPage()->getContent(), TRUE);
+    $this->assertArrayHasKey('integration_module_version', $data);
+
+    /** @var \Drupal\Core\Extension\Extension $extension */
+    $version = \Drupal::service('extension.list.module')->getExtensionInfo('islandora_workbench_integration')['version'] ?? "unknown";
+    $this->assertEquals($version, $data['integration_module_version']);
+  }
+
+}


### PR DESCRIPTION
In addition to adding Drupal 11 support; to ensure there's no regression for 10.x (and this works in Drupal 11) added CI tests for this module. That included linting the codebase using PHP Codesniffer, which pointed out dependency injection should be used for the file hash route, so added that.

```
phpcbf --standard=Drupal --extensions=php .
```

Also updated this module's version controller to read the version from `islandora_workbench_integration.info.yml` instead of hard coding the version number.

The CI tests are passing https://github.com/lehigh-university-libraries/islandora_workbench_integration/actions/runs/14502751514

Closes https://github.com/mjordan/islandora_workbench_integration/issues/34

@mjordan 