### PR TITLE
Multilingual Ingest Support

### DIFF
--- a/islandora_workbench_integration.services.yml
+++ b/islandora_workbench_integration.services.yml
@@ -1,0 +1,5 @@
+services:
+  islandora_workbench_integration.translation_subscriber:
+    class: Drupal\islandora_workbench_integration\EventSubscriber\RequestEventSubscriber
+    tags:
+      - { name: 'event_subscriber' }

--- a/src/EventSubscriber/RequestEventSubscriber.php
+++ b/src/EventSubscriber/RequestEventSubscriber.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * @file
+ * Contains Drupal\islandora_workbench_integration\EventSubscriber\RequestEventSubscriber.
+ */
+
 namespace Drupal\islandora_workbench_integration\EventSubscriber;
 
 use Symfony\Component\HttpKernel\Event\RequestEvent;
@@ -11,40 +16,48 @@ use Drupal\taxonomy\Entity\Term;
 /**
  * Event Subscriber for automatic translation creation.
  */
-class RequestEventSubscriber implements EventSubscriberInterface {
+class RequestEventSubscriber implements EventSubscriberInterface
+{
+
 
   /**
-   * Code that should be triggered on event specified.
+   * Code that should be triggered on event specified
    */
-  public function onRequest(RequestEvent $event) {
+  public function onRequest(RequestEvent $event)
+  {
 
     // Only preload on json/api requests.
     if ($event->getRequest()->getRequestFormat() == 'json' && $event->getRequest()->getMethod() == 'PATCH') {
-      list(, $language, $bundle, $path_part_3, $path_part_4) = explode('/', $event->getRequest()->getPathInfo());
+      $path_info = $this->parseRequestPath($event->getRequest());
 
-      // Create translation only if POST request contains language param.
-      if (!empty($language)) {
+      // Create translation only if POST request contains language param
+      if (!empty($path_info['language'])) {
+        $language = $path_info['language'];
+        $bundle = $path_info['bundle'];
+        $path_part_3 = $path_info['path_part_3'];
+        $path_part_4 = $path_info['path_part_4'];
 
-        // Need to load node and taxonomy term differently.
+        // Need to load node and taxonomy term differently
         if ($bundle == "node") {
           $nid = $path_part_3;
           $node = Node::load($path_part_3);
-          if ($node && !$node->hasTranslation($language)) {
+          if (!$node->hasTranslation($language)) {
             \Drupal::logger('islandora_workbench_integration')->debug(
-              "Node with ID @id has no '@lang' translation: create it!", [
+              "Node with ID @id has no '@lang' translation: create it!",
+              [
                 '@id' => $nid,
                 '@lang' => $language,
               ]
             );
             $node->addTranslation($language, ['title' => $node->label()])->save();
           }
-        }
-        elseif ($bundle == "taxonomy") {
+        } else if ($bundle == "taxonomy") {
           $tid = $path_part_4;
           $term = Term::load($tid);
-          if ($term && !$term->hasTranslation($language)) {
+          if (!$term->hasTranslation($language)) {
             \Drupal::logger('islandora_workbench_integration')->debug(
-              "Term with ID @id has no '@lang' translation: create it!", [
+              "Term with ID @id has no '@lang' translation: create it!",
+              [
                 '@id' => $tid,
                 '@lang' => $language,
               ]
@@ -57,12 +70,27 @@ class RequestEventSubscriber implements EventSubscriberInterface {
   }
 
   /**
+   * Parse request path to extract language, bundle, and path parts.
+   */
+  protected function parseRequestPath($request)
+  {
+    list(, $language, $bundle, $path_part_3, $path_part_4) = explode('/', $request->getPathInfo());
+
+    return [
+      'language' => $language,
+      'bundle' => $bundle,
+      'path_part_3' => $path_part_3,
+      'path_part_4' => $path_part_4 ?? '',
+    ];
+  }
+
+  /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
-    // We need to run before routing.
+  public static function getSubscribedEvents()
+  {
+    // Set a high priority so it is executed before routing.
     $events[KernelEvents::REQUEST][] = ['onRequest', 1000];
     return $events;
   }
-
 }

--- a/src/EventSubscriber/RequestEventSubscriber.php
+++ b/src/EventSubscriber/RequestEventSubscriber.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\islandora_workbench_integration\EventSubscriber;
+
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Event Subscriber for automatic translation creation.
+ */
+class RequestEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Code that should be triggered on event specified.
+   */
+  public function onRequest(RequestEvent $event) {
+
+    // Only preload on json/api requests.
+    if ($event->getRequest()->getRequestFormat() == 'json' && $event->getRequest()->getMethod() == 'PATCH') {
+      list(, $language, $bundle, $path_part_3, $path_part_4) = explode('/', $event->getRequest()->getPathInfo());
+
+      // Create translation only if POST request contains language param.
+      if (!empty($language)) {
+
+        // Need to load node and taxonomy term differently.
+        if ($bundle == "node") {
+          $nid = $path_part_3;
+          $node = Node::load($path_part_3);
+          if ($node && !$node->hasTranslation($language)) {
+            \Drupal::logger('islandora_workbench_integration')->debug(
+              "Node with ID @id has no '@lang' translation: create it!", [
+                '@id' => $nid,
+                '@lang' => $language,
+              ]
+            );
+            $node->addTranslation($language, ['title' => $node->label()])->save();
+          }
+        }
+        elseif ($bundle == "taxonomy") {
+          $tid = $path_part_4;
+          $term = Term::load($tid);
+          if ($term && !$term->hasTranslation($language)) {
+            \Drupal::logger('islandora_workbench_integration')->debug(
+              "Term with ID @id has no '@lang' translation: create it!", [
+                '@id' => $tid,
+                '@lang' => $language,
+              ]
+            );
+            $term->addTranslation($language, ['name' => $term->label()])->save();
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // We need to run before routing.
+    $events[KernelEvents::REQUEST][] = ['onRequest', 1000];
+    return $events;
+  }
+
+}


### PR DESCRIPTION
## Link to Github issue or other discussion
https://github.com/mjordan/islandora_workbench/pull/1026
https://github.com/mjordan/islandora_workbench/issues/259

## What does this PR do?
Allows creating translation content/taxonomy terms from workbench

# #What changes were made?
Module is needed as Drupel currently does not have translation support for PATCHES using REST API.
RequestEventSubscriber intercepts patch requests with langcode and automatically creates translations stub. Users do not have to go into islandora to create each translation stub manually.  